### PR TITLE
Upgrade to kubectl 1.3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update \
 ENV CLOUDSDK_PYTHON_SITEPACKAGES=1
 WORKDIR /root
 
+# Change following ENV value to force SDK version upgrade
+ENV UPDATE_DATE=20160923
 RUN curl https://sdk.cloud.google.com | bash
 RUN bash -c ". google-cloud-sdk/path.bash.inc && gcloud config set disable_usage_reporting false && gcloud components install kubectl"
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build rmi
+
+build:
+	docker build -t tomologic/$(shell basename $(CURDIR)) .
+
+rmi:
+	docker rmi tomologic/$(shell basename $(CURDIR))


### PR DESCRIPTION
It's been 8 months since the kubeadmin image was built. There is no
feature we're missing in our current workflow, but for deployments we
should have a more recent version of the tooling.
