### PR TITLE
Add make to the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
- && apt-get -y install python python-openssl curl \
+ && apt-get -y install python python-openssl curl make \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Prepare installation of the k8s tools


### PR DESCRIPTION
So that there is a fundamental mechanism to perform simple command
orchestration, such as running a jenkins that modifies the GCP state
_within_ the container's context (self-contained and explicitly volument
mounted dependencies).
