### PR TITLE
Bump SDK version to 138

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Prepare installation of the k8s tools
-ENV GOOGLE_CLOUD_SDK_VERSION=137.0.0 \
+ENV GOOGLE_CLOUD_SDK_VERSION=138.0.0 \
     CLOUDSDK_PYTHON_SITEPACKAGES=1 \
     DOWNLOAD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz \
     PATH=$PATH:/root/google-cloud-sdk/bin


### PR DESCRIPTION
Testing merging a commit from one branch onto another, so that they both go into master on the same pull request. I.e. testing simplification of review flow for when we discover master is back-level more than one version compared to the latest gcloud version. It's tedious to review each of these micro-changes individually in such cases.