### PR TITLE
Bump to 140

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Prepare installation of the k8s tools
-ENV GOOGLE_CLOUD_SDK_VERSION=138.0.0 \
+ENV GOOGLE_CLOUD_SDK_VERSION=139.0.1 \
     CLOUDSDK_PYTHON_SITEPACKAGES=1 \
     DOWNLOAD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz \
     PATH=$PATH:/root/google-cloud-sdk/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Prepare installation of the k8s tools
-ENV GOOGLE_CLOUD_SDK_VERSION=139.0.1 \
+ENV GOOGLE_CLOUD_SDK_VERSION=140.0.0 \
     CLOUDSDK_PYTHON_SITEPACKAGES=1 \
     DOWNLOAD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz \
     PATH=$PATH:/root/google-cloud-sdk/bin


### PR DESCRIPTION
We were lagging two version, so will tag both after merge so we get corresponding docker images at dockerhub.

Note: sdk 139 _finally_ includes an updated kubectl to the 1.5 series, meaning we can leverage those new features in our pipeline.