### PR TITLE
Replace Debian with Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,3 +25,4 @@ RUN gcloud config set --installation component_manager/disable_update_check true
 
 COPY ./initialize.sh /root/google-cloud-sdk/bin/initialize
 
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM debian:jessie
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
- && apt-get -y install python python-openssl curl make \
- && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM alpine:3.5
+RUN apk add --no-cache bash curl make python
 
 # Prepare installation of the k8s tools
 ENV GOOGLE_CLOUD_SDK_VERSION=143.0.0 \


### PR DESCRIPTION
To reduce the image size.
Bash is added explicitly so that existing scripts don't break when
mounted and run in the container.