### PR TITLE
Add Helm and bump gcloud version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.5
 RUN apk add --no-cache bash curl make python
 
 # Prepare installation of the k8s tools
-ENV GOOGLE_CLOUD_SDK_VERSION=146.0.0 \
+ENV GOOGLE_CLOUD_SDK_VERSION=152.0.0 \
     CLOUDSDK_PYTHON_SITEPACKAGES=1 \
     DOWNLOAD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz \
     PATH=$PATH:/root/google-cloud-sdk/bin
@@ -22,6 +22,13 @@ RUN google-cloud-sdk/install.sh \
      || gcloud components update --version $GOOGLE_CLOUD_SDK_VERSION)
 
 RUN gcloud config set --installation component_manager/disable_update_check true
+
+# Helm
+ENV HELM_VERSION v2.3.0
+
+RUN curl -so- https://kubernetes-helm.storage.googleapis.com/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xzvf - \
+  && mv /root/linux-amd64/helm /bin/helm \
+  && rm -rvf /root/linux-amd64
 
 COPY ./initialize.sh /root/google-cloud-sdk/bin/initialize
 


### PR DESCRIPTION
Adds helm command line to the image, to support installing software in
Kubernetes using distributed helm charts.

@tomologic/developers 