### PR TITLE
Bump gcloud and helm versions, add helm incubator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.5
 RUN apk add --no-cache bash curl make python
 
 # Prepare installation of the k8s tools
-ENV GOOGLE_CLOUD_SDK_VERSION=152.0.0 \
+ENV GOOGLE_CLOUD_SDK_VERSION=155.0.0 \
     CLOUDSDK_PYTHON_SITEPACKAGES=1 \
     DOWNLOAD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz \
     PATH=$PATH:/root/google-cloud-sdk/bin
@@ -24,12 +24,14 @@ RUN google-cloud-sdk/install.sh \
 RUN gcloud config set --installation component_manager/disable_update_check true
 
 # Helm
-ENV HELM_VERSION v2.3.0
+ENV HELM_VERSION v2.4.2
 
 RUN curl -so- https://kubernetes-helm.storage.googleapis.com/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xzvf - \
   && mv /root/linux-amd64/helm /bin/helm \
   && rm -rvf /root/linux-amd64
 RUN helm init --client-only
+# Besides stable charts add incubator charts too
+RUN helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 
 COPY ./initialize.sh /root/google-cloud-sdk/bin/initialize
 


### PR DESCRIPTION
Routine bump of gcloud and helm versions.
Adding helm incubator repo, separate from stable charts, to get access
to artifactory in particular.

@tomologic/platform 