### PR TITLE
Upgrade to Helm 2.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.5
 RUN apk add --no-cache bash curl make python
 
 # Prepare installation of the k8s tools
-ENV GOOGLE_CLOUD_SDK_VERSION=155.0.0 \
+ENV GOOGLE_CLOUD_SDK_VERSION=159.0.0 \
     CLOUDSDK_PYTHON_SITEPACKAGES=1 \
     DOWNLOAD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz \
     PATH=$PATH:/root/google-cloud-sdk/bin
@@ -24,7 +24,7 @@ RUN google-cloud-sdk/install.sh \
 RUN gcloud config set --installation component_manager/disable_update_check true
 
 # Helm
-ENV HELM_VERSION v2.4.2
+ENV HELM_VERSION v2.5.0
 
 RUN curl -so- https://kubernetes-helm.storage.googleapis.com/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xzvf - \
   && mv /root/linux-amd64/helm /bin/helm \


### PR DESCRIPTION
Many bugs fixed in helm 2.5.0, maintainers recommend upgrading. At the
same time bumping gcloud components version.