### PR TITLE
Make tools available to non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,37 +2,36 @@ FROM alpine:3.7
 RUN apk add --no-cache bash curl make python
 
 # Prepare installation of the k8s tools
-ENV GOOGLE_CLOUD_SDK_VERSION=202.0.0 \
+ENV PATH=/opt/google-cloud-sdk/bin:$PATH \
+    GOOGLE_CLOUD_SDK_VERSION=203.0.0 \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
     CLOUDSDK_PYTHON_SITEPACKAGES=1 \
-    DOWNLOAD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz \
-    PATH=$PATH:/root/google-cloud-sdk/bin
+    GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz
 
-WORKDIR /root
-
-RUN curl -so- $DOWNLOAD_URL | tar -xzf -
-RUN google-cloud-sdk/install.sh \
+RUN mkdir /opt
+RUN curl -sL $GCLOUD_SDK_URL | tar -C /opt -xzf -
+# Install Google Cloud SDK and ensure version is the one specified
+RUN /opt/google-cloud-sdk/install.sh \
     --usage-reporting=false \
     --path-update=true \
     --bash-completion=true \
-    --rc-path=/root/.bashrc \
     --additional-components kubectl alpha beta \
-
-# Ensure the sdk version used is the one specified
- && (gcloud version | grep -q "Google Cloud SDK $GOOGLE_CLOUD_SDK_VERSION" \
-     || gcloud components update --version $GOOGLE_CLOUD_SDK_VERSION)
-
+    && (gcloud version | grep -q "Google Cloud SDK $GOOGLE_CLOUD_SDK_VERSION" \
+    || gcloud components update --version $GOOGLE_CLOUD_SDK_VERSION)
 RUN gcloud config set --installation component_manager/disable_update_check true
 
 # Helm
 ENV HELM_VERSION v2.9.1
 
-RUN curl -so- https://kubernetes-helm.storage.googleapis.com/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xzvf - \
-  && mv /root/linux-amd64/helm /bin/helm \
-  && rm -rvf /root/linux-amd64
+RUN mkdir /opt/helm \
+    && curl -sL https://kubernetes-helm.storage.googleapis.com/helm-${HELM_VERSION}-linux-amd64.tar.gz \
+       | tar -C /opt/helm -xzvf - \
+    && mv /opt/helm/linux-amd64/helm /bin/helm \
+    && rm -rvf /opt/helm
 RUN helm init --client-only
 # Besides stable charts add incubator charts too
 RUN helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 
-COPY ./initialize.sh /root/google-cloud-sdk/bin/initialize
+COPY ./initialize.sh /opt/google-cloud-sdk/bin/initialize
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
When running kubeadmin with a different user than root by passing the
"-u" flag to docker run, the following tools were unavailable:
* gcloud
* kubectl
* helm

By installing them outside of /root directory we make them available
even when using container as non-root user.

INF-6951